### PR TITLE
issue #9057 Allow calling external mscgen

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3514,6 +3514,18 @@ where `loc1` and `loc2` can be relative or absolute paths or URLs.
       </docs>
     </option>
   </group>
+  <group name='Msc' docs='Configuration options related to message sequence charts (MSC)'>
+    <option type='string' id='MSCGEN' format='file' defval=''>
+      <docs>
+<![CDATA[
+ You can define MSCs within doxygen comments using the \ref cmdmsc "\\msc"
+ command. Doxygen will either use an internal tool to produce the chart, or if
+ specified the <code>MSCGEN</code> tag allows you to use an external program
+ for that.
+]]>
+      </docs>
+    </option>
+  </group>
   <group name='Dot' docs='Configuration options related to the dot tool'>
     <option type='string' id='DIA_PATH' format='dir' defval=''>
       <docs>

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -92,7 +92,7 @@ static bool convertMapFile(TextStream &t,const QCString &mapName,const QCString 
 bool do_mscgen_generate(const QCString& inFile,const QCString& outFile,mscgen_format_t msc_format,
                      const QCString &srcFile,int srcLine)
 {
-  QCString external_mscgen = Portable::getenv("MSCGEN_PATH");//TODO use ConfigValues::instance().MSCGEN_PATH() instead
+  QCString const& external_mscgen = Config_getString(MSCGEN);
   if (!external_mscgen.isEmpty()) {
     QCString type;
     switch (msc_format)
@@ -114,7 +114,7 @@ bool do_mscgen_generate(const QCString& inFile,const QCString& outFile,mscgen_fo
     int exitcode = Portable::system(external_mscgen,"-T"+type+" -o "+outFile+" "+inFile);
     if (exitcode==0)
       return true;
-    warn(srcFile,srcLine,"Problems running %s given with MSCGEN_PATH (exit status %d); check your installation. Trying with internal mscgen instead.",
+    warn(srcFile,srcLine,"Problems running %s given with MSCGEN (exit status: %d); check your installation. Trying with internal mscgen instead.",
         external_mscgen.data(),exitcode);
   }
   int code = mscgen_generate(inFile.data(),outFile.data(),msc_format);


### PR DESCRIPTION
Resurrect pre-1.9 functionality to allow calling external `mscgen` for producing MSCs. In particular, this enables to use msc-generator[1] again for such charts -- which is a commandline-compatible alternative MSC generator with much extended syntax than the original `mscgen`.

[1] https://sourceforge.net/projects/msc-generator